### PR TITLE
Add unit tests for chunking, embeddings, and RAG

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,75 @@
+import sys
+import types
+import pathlib
+import pytest
+
+pytest.importorskip('fastapi')
+
+# ensure backend package on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'backend'))
+
+# minimal stubs for heavy dependencies before importing routers
+pydantic_mod = types.ModuleType('pydantic')
+class BaseModel: ...
+pydantic_mod.BaseModel = BaseModel
+sys.modules.setdefault('pydantic', pydantic_mod)
+
+embedding_pkg = types.ModuleType('embedding')
+embedder_base = types.ModuleType('embedding.embedder_base')
+embedder_base.HuggingFaceEmbedder = object
+embedder_base.OpenAIEmbedder = object
+embedder_base.GeminiEmbedder = object
+embedding_manager_mod = types.ModuleType('embedding.embedding_manager')
+class EmbeddingManager: ...
+embedding_manager_mod.EmbeddingManager = EmbeddingManager
+vector_store_mod = types.ModuleType('embedding.vector_store')
+class Neo4jVectorManager:
+    def __init__(self, *args, **kwargs):
+        pass
+    def test_connection(self):
+        return True
+vector_store_mod.Neo4jVectorManager = Neo4jVectorManager
+embedding_pipeline = types.ModuleType('embedding.embedding_pipeline')
+embedding_pkg.embedder_base = embedder_base
+embedding_pkg.embedding_manager = embedding_manager_mod
+embedding_pkg.vector_store = vector_store_mod
+embedding_pkg.embedding_pipeline = embedding_pipeline
+sys.modules['embedding'] = embedding_pkg
+sys.modules['embedding.embedder_base'] = embedder_base
+sys.modules['embedding.embedding_manager'] = embedding_manager_mod
+sys.modules['embedding.vector_store'] = vector_store_mod
+sys.modules['embedding.embedding_pipeline'] = embedding_pipeline
+
+knowledge_pkg = types.ModuleType('knowledge')
+graph_builder = types.ModuleType('knowledge.graph_builder')
+class GraphBuilder: ...
+graph_builder.GraphBuilder = GraphBuilder
+schema_manager = types.ModuleType('knowledge.schema_manager')
+class GraphSchemaManager: ...
+schema_manager.GraphSchemaManager = GraphSchemaManager
+kg_builder = types.ModuleType('knowledge.kg_builder')
+class KGBuilder:
+    def __init__(self, *args, **kwargs):
+        pass
+    def check_kg_exists(self):
+        return True
+kg_builder.KGBuilder = KGBuilder
+knowledge_pkg.graph_builder = graph_builder
+knowledge_pkg.schema_manager = schema_manager
+knowledge_pkg.kg_builder = kg_builder
+sys.modules['knowledge'] = knowledge_pkg
+sys.modules['knowledge.graph_builder'] = graph_builder
+sys.modules['knowledge.schema_manager'] = schema_manager
+sys.modules['knowledge.kg_builder'] = kg_builder
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app.api import api_router
+
+def test_status_api_endpoint():
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+    resp = client.get('/api/v1/status/api')
+    assert resp.status_code == 200
+    assert resp.json() == {'ok': True}

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,27 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'backend'))
+from ingestion.chunker import Chunker
+
+@pytest.fixture
+def sample_file(tmp_path):
+    version_dir = tmp_path / 'v1'
+    version_dir.mkdir()
+    file_path = version_dir / 'doc.txt'
+    content = 'Hello world. This is a test.'
+    file_path.write_text(content)
+    return tmp_path, 'v1', 'doc', 'txt', content
+
+def test_get_text_file_reads_content(sample_file):
+    extracted_dir, version, fname, fext, content = sample_file
+    chunker = Chunker(extracted_dir=str(extracted_dir))
+    text = chunker.get_text_file(version, fname, fext)
+    assert text == content
+
+def test_character_split_generates_chunks():
+    chunker = Chunker(chunk_size=10, chunk_overlap=0)
+    text = 'abcdefghij1234567890'
+    chunks = chunker.character_split(text)
+    assert chunks == ['abcdefghij', '1234567890']

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,66 @@
+import sys
+import types
+import pathlib
+import pytest
+
+# Add backend to path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'backend'))
+
+# Stub embedding manager and vector store before importing Retriever
+embedding_pkg = types.ModuleType('embedding')
+embedding_manager_mod = types.ModuleType('embedding.embedding_manager')
+class FakeEmbeddingManager:
+    def __init__(self, *args, **kwargs):
+        pass
+    def embed_texts(self, texts):
+        return [[0.1, 0.2, 0.3] for _ in texts]
+embedding_manager_mod.EmbeddingManager = FakeEmbeddingManager
+vector_store_mod = types.ModuleType('embedding.vector_store')
+class FakeVectorStore:
+    def __init__(self, *args, **kwargs):
+        pass
+    def search_similar(self, embedding, k=5):
+        return [{'score': 0.9, 'text': 'Alice met Bob.'}]
+vector_store_mod.Neo4jVectorManager = FakeVectorStore
+embedding_pkg.embedding_manager = embedding_manager_mod
+embedding_pkg.vector_store = vector_store_mod
+sys.modules['embedding'] = embedding_pkg
+sys.modules['embedding.embedding_manager'] = embedding_manager_mod
+sys.modules['embedding.vector_store'] = vector_store_mod
+
+# stub neo4j driver and type
+neo4j_mod = types.ModuleType('neo4j')
+class Driver: ...
+class GraphDatabase:
+    @staticmethod
+    def driver(url, auth):
+        return object()
+neo4j_mod.Driver = Driver
+neo4j_mod.GraphDatabase = GraphDatabase
+sys.modules['neo4j'] = neo4j_mod
+
+from rag.retriever import Retriever
+
+class DummySession:
+    def run(self, cypher, ents):
+        return [{'name': 'Alice', 'labels': ['Person']}]
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyDriver:
+    def session(self):
+        return DummySession()
+
+@pytest.fixture
+def retriever():
+    embedder = FakeEmbeddingManager()
+    vstore = FakeVectorStore()
+    driver = DummyDriver()
+    return Retriever(embedder, vstore, driver)
+
+def test_retrieve_combines_sources(retriever):
+    result = retriever.retrieve('Who is Alice?')
+    assert result['vector_hits'][0]['text'] == 'Alice met Bob.'
+    assert result['cypher_hits'][0]['name'] == 'Alice'

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,59 @@
+import sys
+import types
+import pathlib
+from unittest.mock import MagicMock
+import pytest
+
+# ensure backend modules are used, not previous stubs
+sys.modules.pop('embedding', None)
+sys.modules.pop('embedding.vector_store', None)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'backend'))
+
+class DummySession:
+    def __init__(self):
+        self.run = MagicMock()
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyDriver:
+    def __init__(self, session):
+        self._session = session
+    def session(self, database=None):
+        return self._session
+
+if 'neo4j' not in sys.modules:
+    neo4j = types.ModuleType('neo4j')
+    class DummyGraphDatabase:
+        @staticmethod
+        def driver(url, auth):
+            return DummyDriver(DummySession())
+    neo4j.GraphDatabase = DummyGraphDatabase
+    sys.modules['neo4j'] = neo4j
+
+from embedding.vector_store import Neo4jVectorManager
+
+@pytest.fixture
+def manager():
+    session = DummySession()
+    driver = DummyDriver(session)
+    mgr = Neo4jVectorManager(url='bolt://x', username='u', password='p')
+    mgr.driver = driver
+    return mgr, session
+
+def test_save_builds_rows(manager):
+    mgr, session = manager
+    mgr.save(texts=['foo'], embeddings=[[0.1]], version='v1')
+    session.run.assert_called_once()
+    args, kwargs = session.run.call_args
+    assert kwargs['rows'][0]['text'] == 'foo'
+    assert kwargs['rows'][0]['embedding'] == [0.1]
+    assert kwargs['rows'][0]['version'] == 'v1'
+
+def test_search_similar_formats_results(manager):
+    mgr, session = manager
+    session.run.return_value = [{'score': 1.0, 'node': {'text': 'hello'}}]
+    results = mgr.search_similar([0.1], k=1)
+    assert results == [{'score': 1.0, 'text': 'hello'}]


### PR DESCRIPTION
## Summary
- add ingestion tests to confirm chunk file reading and character splitting
- add vector store tests mocking Neo4j to check save and similarity search
- add RAG retriever test combining vector hits and KG hits
- add minimal FastAPI integration test for status endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68992a49de5483208b1ed760d1eb9882